### PR TITLE
Add runs count selector for firmware fetch

### DIFF
--- a/src/components/tabs/flasher/FirmwarePanel.tsx
+++ b/src/components/tabs/flasher/FirmwarePanel.tsx
@@ -9,6 +9,8 @@ import {
   SelectItem,
 } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Loader2,
   CheckCircle2,
@@ -127,6 +129,7 @@ export default function FirmwarePanel({
   const { t } = useTranslation()
   const [isLoadingLatestFirmwares, setIsLoadingLatestFirmwares] =
     useState(false)
+  const [runsCount, setRunsCount] = useState<number>(3)
 
   // リポジトリストアからselectedWorkflowを取得
   const { getSelectedWorkflow } = useRepositoriesStore()
@@ -156,7 +159,8 @@ export default function FirmwarePanel({
       const newFirmwares = await fetchLatestFirmware(
         selectedRepo,
         selectedWorkflow.id,
-        refLifetimeAbort.current.signal
+        refLifetimeAbort.current.signal,
+        runsCount
       )
 
       // 親コンポーネントにファームウェアリストを更新
@@ -222,17 +226,31 @@ export default function FirmwarePanel({
                       placeholder={t('flasher.firmwarePanel.selectWorkflow')}
                     />
                   </SelectTrigger>
-                  <SelectContent>
-                    {workflows.map((workflow) => (
-                      <SelectItem
-                        key={workflow.id}
-                        value={workflow.id.toString()}
-                      >
-                        {workflow.name} ({workflow.path})
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <SelectContent>
+                  {workflows.map((workflow) => (
+                    <SelectItem
+                      key={workflow.id}
+                      value={workflow.id.toString()}
+                    >
+                      {workflow.name} ({workflow.path})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <div className="grid grid-cols-3 items-center gap-2">
+                <Label htmlFor="runs-count">
+                  {t('flasher.firmwarePanel.runsCount')}
+                </Label>
+                <Input
+                  id="runs-count"
+                  type="number"
+                  min={1}
+                  value={runsCount}
+                  onChange={(e) => setRunsCount(Number(e.target.value))}
+                  className="col-span-2"
+                />
+              </div>
 
                 <div className="flex justify-between items-center">
                   <h4 className="text-sm font-medium">

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -28,6 +28,7 @@
       "title": "Firmware Selection",
       "noFirmware": "No firmware available",
       "selectWorkflow": "Select workflow",
+      "runsCount": "Number of runs",
       "noWorkflows": "No workflows found",
       "selectFirmware": "Select firmware",
       "refresh": "Get latest firmware",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -28,6 +28,7 @@
       "title": "ファームウェア選択",
       "noFirmware": "利用可能なファームウェアがありません",
       "selectWorkflow": "ワークフローを選択",
+      "runsCount": "取得するラン数",
       "noWorkflows": "ワークフローが見つかりません",
       "selectFirmware": "ファームウェアを選択",
       "refresh": "最新のファームウェアを取得",


### PR DESCRIPTION
## Summary
- allow user to specify the number of workflow runs to fetch
- show a numeric input in FirmwarePanel
- localize new "runs count" label in English and Japanese translations

## Testing
- `npm test`
- `npm run lint` *(fails: React version not specified and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c22c0234832a9f6adef3b2b7e68c